### PR TITLE
[#6] Feat: 저장소 조회 API 구현

### DIFF
--- a/src/main/java/com/example/triptalk/domain/tripPlan/controller/TripPlanController.java
+++ b/src/main/java/com/example/triptalk/domain/tripPlan/controller/TripPlanController.java
@@ -1,16 +1,14 @@
 package com.example.triptalk.domain.tripPlan.controller;
 
 import com.example.triptalk.domain.tripPlan.dto.TripPlanResponse;
+import com.example.triptalk.domain.tripPlan.enums.TripStatus;
 import com.example.triptalk.domain.tripPlan.service.TripPlanService;
 import com.example.triptalk.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/trip-plan")
@@ -28,6 +26,19 @@ public class TripPlanController {
     ) {
         // 인증 구현 후 SecurityContext에서 로그인한 userId 가져오기
         TripPlanResponse.TripPlanDTO response = tripPlanService.getTripPlan(tripPlanId, 1L);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/archive")
+    @Operation(summary = "저장소 조회", description = "상태(status)별로 여행 일정을 커서 기반 무한스크롤로 조회합니다.")
+    public ApiResponse<TripPlanResponse.TripPlanListResultDTO> getMyTripPlans(
+            @Parameter(description = "여행 상태 필터", example = "PLANNED", required = true)
+            @RequestParam TripStatus status,
+            @Parameter(description = "다음 커서 ID (처음 요청 시 null)", example = "null")
+            @RequestParam(required = false) Long cursorId
+    ) {
+        // 인증 구현 후 SecurityContext에서 로그인한 userId 가져오기
+        TripPlanResponse.TripPlanListResultDTO response = tripPlanService.getMyTripPlans(1L, status, cursorId);
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/example/triptalk/domain/tripPlan/converter/TripPlanConverter.java
+++ b/src/main/java/com/example/triptalk/domain/tripPlan/converter/TripPlanConverter.java
@@ -3,6 +3,7 @@ package com.example.triptalk.domain.tripPlan.converter;
 import com.example.triptalk.domain.tripPlan.dto.TripPlanResponse;
 import com.example.triptalk.domain.tripPlan.entity.*;
 import com.example.triptalk.domain.tripPlan.enums.TravelStyle;
+import org.springframework.data.domain.Slice;
 
 import java.util.HashSet;
 import java.util.List;
@@ -89,6 +90,49 @@ public class TripPlanConverter {
                         .content(h.getContent())
                         .build())
                 .toList();
+    }
+
+    /**
+     * TripPlan 엔티티를 TripPlanSliceDTO로 변환
+     * - 저장소 조회(목록)에 필요한 필드만 포함
+     */
+    public static TripPlanResponse.TripPlanSliceDTO toTripPlanSliceDTO(
+            TripPlan tripPlan,
+            List<TripTransportation> transportations,
+            List<TripAccommodation> accommodations
+    ){
+        return TripPlanResponse.TripPlanSliceDTO.builder()
+                .id(tripPlan.getId())
+                .title(tripPlan.getTitle())
+                .transportations(toTransportationDTO(transportations))
+                .accommodations(toAccommodationDTO(accommodations))
+                .startDate(tripPlan.getStartDate())
+                .endDate(tripPlan.getEndDate())
+                .status(tripPlan.getStatus().toString())
+                .imageUrl(tripPlan.getImgUrl())
+                .build();
+    }
+
+    /**
+     * Slice<TripPlan>과 관련 데이터를 TripPlanListResultDTO로 변환
+     * - 커서 기반 페이징 메타데이터 포함
+     */
+    public static TripPlanResponse.TripPlanListResultDTO toTripPlanListResultDTO(
+            Slice<TripPlan> slice,
+            List<TripPlanResponse.TripPlanSliceDTO> tripPlanList
+    ) {
+        // 다음 커서 ID는 마지막 항목의 ID
+        Long nextCursorId = tripPlanList.isEmpty() ?
+                null :
+                tripPlanList.getLast().getId();
+
+        return TripPlanResponse.TripPlanListResultDTO.builder()
+                .tripPlanList(tripPlanList)
+                .tripPlanListSize(tripPlanList.size())
+                .isFirst(slice.isFirst())
+                .hasNext(slice.hasNext())
+                .nextCursorId(nextCursorId)
+                .build();
     }
 }
 

--- a/src/main/java/com/example/triptalk/domain/tripPlan/dto/TripPlanResponse.java
+++ b/src/main/java/com/example/triptalk/domain/tripPlan/dto/TripPlanResponse.java
@@ -152,4 +152,59 @@ public class TripPlanResponse {
         private String content;
 
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "여행 일정 목록 조회 응답 (커서 기반 슬라이스)")
+    public static class TripPlanSliceDTO {
+
+        @Schema(description = "여행 일정 ID", example = "1")
+        private Long id;
+
+        @Schema(description = "여행 제목", example = "제주도 3박 4일 힐링 & 자연 여행")
+        private String title;
+
+        @Schema(description = "교통편 목록")
+        private List<TransportationDTO> transportations;
+
+        @Schema(description = "숙소 목록")
+        private List<AccommodationDTO> accommodations;
+
+        @Schema(description = "시작일", example = "2025-03-15")
+        private LocalDate startDate;
+
+        @Schema(description = "종료일", example = "2025-03-18")
+        private LocalDate endDate;
+
+        @Schema(description = "상태", example = "PLANNED")
+        private String status;
+
+        @Schema(description = "대표 이미지 URL", example = "https://example.com/images/jeju_trip.jpg")
+        private String imageUrl;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "여행 일정 목록 조회 응답 (저장소)")
+    public static class TripPlanListResultDTO {
+
+        @Schema(description = "여행 일정 목록")
+        private List<TripPlanSliceDTO> tripPlanList;
+
+        @Schema(description = "현재 페이지의 여행 일정 개수", example = "10")
+        private Integer tripPlanListSize;
+
+        @Schema(description = "페이지 처음 여부", example = "true")
+        private Boolean isFirst;
+
+        @Schema(description = "다음 페이지가 있는지 여부", example = "true")
+        private Boolean hasNext;
+
+        @Schema(description = "다음 커서 ID (무한스크롤용)", example = "1")
+        private Long nextCursorId;
+    }
 }

--- a/src/main/java/com/example/triptalk/domain/tripPlan/repository/TripPlanRepository.java
+++ b/src/main/java/com/example/triptalk/domain/tripPlan/repository/TripPlanRepository.java
@@ -1,7 +1,9 @@
 package com.example.triptalk.domain.tripPlan.repository;
 
 import com.example.triptalk.domain.tripPlan.entity.TripPlan;
-import org.springframework.data.jpa.repository.EntityGraph;
+import com.example.triptalk.domain.tripPlan.enums.TripStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,5 +17,16 @@ public interface TripPlanRepository extends JpaRepository<TripPlan, Long> {
            "LEFT JOIN FETCH tp.user " +
            "WHERE tp.id = :id")
     Optional<TripPlan> findWithAllById(@Param("id") Long id);
+
+    @Query("SELECT tp FROM TripPlan tp " +
+           "WHERE tp.user.id = :userId AND tp.status = :status " +
+           "AND (:cursorId IS NULL OR tp.id < :cursorId) " +
+           "ORDER BY tp.id DESC")
+    Slice<TripPlan> findMyTripPlans(
+            @Param("userId") Long userId,
+            @Param("status") TripStatus status,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable
+    );
 }
 

--- a/src/main/java/com/example/triptalk/domain/tripPlan/service/TripPlanService.java
+++ b/src/main/java/com/example/triptalk/domain/tripPlan/service/TripPlanService.java
@@ -1,10 +1,14 @@
 package com.example.triptalk.domain.tripPlan.service;
 
 import com.example.triptalk.domain.tripPlan.dto.TripPlanResponse;
+import com.example.triptalk.domain.tripPlan.enums.TripStatus;
 
 public interface TripPlanService {
 
     // 여행 계획 단일 조회
     TripPlanResponse.TripPlanDTO getTripPlan(Long tripPlanId, Long userId);
+
+    // 저장소 조회 (status별 커서 기반 무한스크롤)
+    TripPlanResponse.TripPlanListResultDTO getMyTripPlans(Long userId, TripStatus status, Long cursorId);
 }
 

--- a/src/main/java/com/example/triptalk/domain/tripPlan/service/TripPlanServiceImpl.java
+++ b/src/main/java/com/example/triptalk/domain/tripPlan/service/TripPlanServiceImpl.java
@@ -3,21 +3,23 @@ package com.example.triptalk.domain.tripPlan.service;
 import com.example.triptalk.domain.tripPlan.converter.TripPlanConverter;
 import com.example.triptalk.domain.tripPlan.dto.TripPlanResponse;
 import com.example.triptalk.domain.tripPlan.entity.TripPlan;
+import com.example.triptalk.domain.tripPlan.enums.TripStatus;
 import com.example.triptalk.domain.tripPlan.repository.*;
-import com.example.triptalk.domain.user.entity.User;
-import com.example.triptalk.domain.user.repository.UserRepository;
 import com.example.triptalk.global.apiPayload.code.status.ErrorStatus;
 import com.example.triptalk.global.apiPayload.exception.handler.ErrorHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class TripPlanServiceImpl implements TripPlanService {
 
-    private final UserRepository userRepository;
     private final TripPlanRepository tripPlanRepository;
     private final TripTransportationRepository tripTransportationRepository;
     private final TripAccommodationRepository tripAccommodationRepository;
@@ -27,26 +29,45 @@ public class TripPlanServiceImpl implements TripPlanService {
     @Override
     public TripPlanResponse.TripPlanDTO getTripPlan(Long tripPlanId, Long userId) {
 
-        // 1. 사용자 확인
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
-
-        // 2. 여행 계획 조회 (travelStyles, user fetch join)
+        // 1. 여행 계획 조회 (travelStyles, user fetch join)
         TripPlan tripPlan = tripPlanRepository.findWithAllById(tripPlanId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.TRIP_PLAN_NOT_FOUND));
 
-        // 3. 권한 확인
+        // 2. 권한 확인
         if (!tripPlan.getUser().getId().equals(userId)) {
             throw new ErrorHandler(ErrorStatus._FORBIDDEN);
         }
 
-        // 4. 연관 데이터 조회
+        // 3. 연관 데이터 조회
         var transportations = tripTransportationRepository.findByTripPlanId(tripPlanId);
         var accommodations = tripAccommodationRepository.findByTripPlanId(tripPlanId);
         var dailySchedules = dailyScheduleRepository.findByTripPlanIdWithItemsOrderByDayAsc(tripPlanId);
         var highlights = tripHighlightRepository.findByTripPlanId(tripPlanId);
 
         return TripPlanConverter.toTripPlanDTO(tripPlan, transportations, accommodations, dailySchedules, highlights);
+    }
+
+    @Override
+    public TripPlanResponse.TripPlanListResultDTO getMyTripPlans(Long userId, TripStatus status, Long cursorId) {
+
+        // 고정 페이지 크기 5개
+        final int PAGE_SIZE = 5;
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE);
+
+        // 1. 조회
+        Slice<TripPlan> slice = tripPlanRepository.findMyTripPlans(userId, status, cursorId, pageable);
+
+        // 2. 각 TripPlan별 교통편과 숙소 정보 조회
+        var tripPlanListWithDetails = slice.getContent().stream()
+                .map(tripPlan -> {
+                    var transportations = tripTransportationRepository.findByTripPlanId(tripPlan.getId());
+                    var accommodations = tripAccommodationRepository.findByTripPlanId(tripPlan.getId());
+                    return TripPlanConverter.toTripPlanSliceDTO(tripPlan, transportations, accommodations);
+                })
+                .toList();
+
+        // 3. dto 변환 및 반환
+        return TripPlanConverter.toTripPlanListResultDTO(slice, tripPlanListWithDetails);
     }
 }
 

--- a/src/main/java/com/example/triptalk/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/triptalk/domain/user/service/UserServiceImpl.java
@@ -5,7 +5,6 @@ import com.example.triptalk.domain.user.dto.UserResponse;
 import com.example.triptalk.domain.user.entity.User;
 import com.example.triptalk.domain.user.repository.UserRepository;
 import com.example.triptalk.global.apiPayload.code.status.ErrorStatus;
-import com.example.triptalk.global.apiPayload.exception.GeneralException;
 import com.example.triptalk.global.apiPayload.exception.handler.ErrorHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
-    private final UserConverter userConverter;
 
     @Override
     public UserResponse.UserInfoDTO getUserInfo(Long userId) {
@@ -27,7 +25,7 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
         // 2. 응답 DTO 변환 및 반환
-        return userConverter.toUserInfoDTO(user);
+        return UserConverter.toUserInfoDTO(user);
     }
 }
 


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #6 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 저장소 조회 API 구현
  - 엔드포인트 : `GET /api/trip-plan/archive`
  - 커서 기반 무한스크롤
  - status에 따라 조회 가능
 
## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
<img width="1151" height="425" alt="image" src="https://github.com/user-attachments/assets/31c31655-2bb1-4b01-8abe-825eb7ade7e7" />


## ✅ 체크리스트
- [ ] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 여행 계획 필터링 및 조회 기능 추가: 상태별로 여행 계획을 필터링하여 조회할 수 있으며, 커서 기반 페이지네이션을 통해 효율적으로 여행 계획 목록을 불러올 수 있습니다. 각 항목에는 제목, 여행 기간, 상태, 이미지 등의 주요 정보가 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->