### PR TITLE
[#12] Feat: TripPlan 여행 완료 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/example/triptalk/domain/tripPlan/controller/TripPlanController.java
+++ b/src/main/java/com/example/triptalk/domain/tripPlan/controller/TripPlanController.java
@@ -41,5 +41,15 @@ public class TripPlanController {
         TripPlanResponse.TripPlanListResultDTO response = tripPlanService.getMyTripPlans(1L, status, cursorId);
         return ApiResponse.onSuccess(response);
     }
-}
 
+    @PatchMapping("/{tripPlanId}/traveled")
+    @Operation(summary = "여행 상태 완료 처리", description = "여행 계획의 상태를 PLANNED에서 TRAVELED로 변경합니다.")
+    public ApiResponse<TripPlanResponse.TripPlanStatusDTO> markTripPlanAsTraveled(
+            @Parameter(description = "tripPlan ID", example = "1", required = true)
+            @PathVariable Long tripPlanId
+    ) {
+        // 인증 구현 후 SecurityContext에서 로그인한 userId 가져오기
+        TripPlanResponse.TripPlanStatusDTO response = tripPlanService.changeTripPlanStatusToTraveled(tripPlanId, 1L);
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/example/triptalk/domain/tripPlan/converter/TripPlanConverter.java
+++ b/src/main/java/com/example/triptalk/domain/tripPlan/converter/TripPlanConverter.java
@@ -134,5 +134,14 @@ public class TripPlanConverter {
                 .nextCursorId(nextCursorId)
                 .build();
     }
-}
 
+    /**
+     * TripPlan 엔티티를 TripPlanStatusDTO로 변환
+     */
+    public static TripPlanResponse.TripPlanStatusDTO toTripPlanStatusDTO(TripPlan tripPlan) {
+        return TripPlanResponse.TripPlanStatusDTO.builder()
+                .id(tripPlan.getId())
+                .status(tripPlan.getStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/com/example/triptalk/domain/tripPlan/dto/TripPlanResponse.java
+++ b/src/main/java/com/example/triptalk/domain/tripPlan/dto/TripPlanResponse.java
@@ -207,4 +207,18 @@ public class TripPlanResponse {
         @Schema(description = "다음 커서 ID (무한스크롤용)", example = "1")
         private Long nextCursorId;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "상태 변경 응답 (TripPlan id와 status)")
+    public static class TripPlanStatusDTO {
+
+        @Schema(description = "여행 일정 ID", example = "1")
+        private Long id;
+
+        @Schema(description = "상태", example = "TRAVELED")
+        private String status;
+    }
 }

--- a/src/main/java/com/example/triptalk/domain/tripPlan/service/TripPlanService.java
+++ b/src/main/java/com/example/triptalk/domain/tripPlan/service/TripPlanService.java
@@ -10,5 +10,7 @@ public interface TripPlanService {
 
     // 저장소 조회 (status별 커서 기반 무한스크롤)
     TripPlanResponse.TripPlanListResultDTO getMyTripPlans(Long userId, TripStatus status, Long cursorId);
-}
 
+    // 여행 상태 변경: PLANNED -> TRAVELED
+    TripPlanResponse.TripPlanStatusDTO changeTripPlanStatusToTraveled(Long tripPlanId, Long userId);
+}

--- a/src/main/java/com/example/triptalk/domain/tripPlan/service/TripPlanServiceImpl.java
+++ b/src/main/java/com/example/triptalk/domain/tripPlan/service/TripPlanServiceImpl.java
@@ -69,5 +69,28 @@ public class TripPlanServiceImpl implements TripPlanService {
         // 3. dto 변환 및 반환
         return TripPlanConverter.toTripPlanListResultDTO(slice, tripPlanListWithDetails);
     }
-}
 
+    @Override
+    @Transactional
+    public TripPlanResponse.TripPlanStatusDTO changeTripPlanStatusToTraveled(Long tripPlanId, Long userId) {
+        // 1. 조회
+        TripPlan tripPlan = tripPlanRepository.findWithAllById(tripPlanId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.TRIP_PLAN_NOT_FOUND));
+
+        // 2. 권한 확인
+        if (!tripPlan.getUser().getId().equals(userId)) {
+            throw new ErrorHandler(ErrorStatus._FORBIDDEN);
+        }
+
+        // 3. 상태 확인
+        if (tripPlan.getStatus() == TripStatus.TRAVELED) {
+            throw new ErrorHandler(ErrorStatus.TRIP_PLAN_ALREADY_TRAVELED);
+        }
+
+        // 4. 상태 변경 및 저장
+        tripPlan.setStatus(TripStatus.TRAVELED);
+        tripPlanRepository.save(tripPlan);
+
+        return TripPlanConverter.toTripPlanStatusDTO(tripPlan);
+    }
+}

--- a/src/main/java/com/example/triptalk/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/triptalk/global/apiPayload/code/status/ErrorStatus.java
@@ -21,7 +21,8 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER401", "아이디와 일치하는 사용자가 없습니다."),
 
     // 여행 계획 관련 에러
-    TRIP_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "TRIP_PLAN401", "존재하지 않는 여행 계획입니다.");
+    TRIP_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "TRIP_PLAN401", "존재하지 않는 여행 계획입니다."),
+    TRIP_PLAN_ALREADY_TRAVELED(HttpStatus.BAD_REQUEST, "TRIP_PLAN402", "이미 완료된(Traveled) 여행 계획입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
<!-- PR 제목 예시-> ✨[Feat]: 소셜 로그인 기능 구현 -->

## #️⃣ 연관된 이슈
> - #12 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- TripPlan의 상태를 **PLANNED에서 TRAVELED**로 변경
  - 엔드포인트 : `PATCH /api/trip-plan/{tripPlanId}/traveled`
  - `TRIP_PLAN_ALREADY_TRAVELED` : 이미 여행 완료 처리 error
  - `TRIP_PLAN_NOT_FOUND` : 여행 계획 찾을 수 없음

## 📌 공유 사항
<!-- 팀원들에게 공유헤야 할 사항이 있다면 작성해주세요 -->
-  

## ✅ 체크리스트
- [ ] Reviewer에 팀원들을 선택 했나요?
- [x] Assignees에 본인을 선택 했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [ ] 불필요한 주석이 제거되었나요?
- [ ] 코드 스타일이 일관적인가요?

## 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? or 변경 사항 등


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 여행 계획을 "완료됨" 상태로 표시할 수 있는 새로운 기능이 추가되었습니다
  * 이미 완료된 여행 계획에 대한 중복 표시를 방지하는 유효성 검사가 포함되었습니다

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->